### PR TITLE
Migration to cmssw 810 pre8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ services:
 env:
   - DOCKER_IMAGE=grzanka/cmssw_810:pre8 CMSSW_VER=CMSSW_8_1_0_pre8
   - DOCKER_IMAGE=grzanka/cmssw_810:pre5 CMSSW_VER=CMSSW_8_1_0_pre5
-  - DOCKER_IMAGE=grzanka/cmssw_810:pre4 CMSSW_VER=CMSSW_8_1_0_pre4
 
 # here we can define the sub-builds which can fail (and won't mark whole build as failed)
-#matrix:
-#    allow_failures:
-#        - env: DOCKER_IMAGE=grzanka/cmssw_810:pre5 CMSSW_VER=CMSSW_8_1_0_pre5
+matrix:
+    allow_failures:
+        - env: DOCKER_IMAGE=grzanka/cmssw_810:pre5 CMSSW_VER=CMSSW_8_1_0_pre5
 
 language: bash
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 
 # matrix build
 env:
+  - DOCKER_IMAGE=grzanka/cmssw_810:pre8 CMSSW_VER=CMSSW_8_1_0_pre8
   - DOCKER_IMAGE=grzanka/cmssw_810:pre5 CMSSW_VER=CMSSW_8_1_0_pre5
   - DOCKER_IMAGE=grzanka/cmssw_810:pre4 CMSSW_VER=CMSSW_8_1_0_pre4
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ migrated to newer version of CMSSW framework.
 ```
 ssh -X $USER@lxplus
 source /afs/cern.ch/cms/cmsset_default.sh
-cmsrel CMSSW_8_1_0_pre5
-git clone https://github.com/CTPPS/ctpps-offline.git CMSSW_8_1_0_pre5/src
-cd CMSSW_8_1_0_pre5/src
+cmsrel CMSSW_8_1_0_pre8
+git clone https://github.com/CTPPS/ctpps-offline.git CMSSW_8_1_0_pre8/src
+cd CMSSW_8_1_0_pre8/src
 cmsenv
 scram build -j 15
 ```

--- a/TotemProtonTransport/TotemRPProtonTransportParametrization/interface/RPXMLConfig.h
+++ b/TotemProtonTransport/TotemRPProtonTransportParametrization/interface/RPXMLConfig.h
@@ -6,7 +6,6 @@
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/dom/DOMNodeList.hpp>
 #include <xercesc/dom/DOMElement.hpp>
-#include <xercesc/dom/DOMWriter.hpp>
 #include <xercesc/dom/DOMImplementation.hpp>
 #include <xercesc/dom/DOMImplementationLS.hpp>
 #include <xercesc/util/XMLString.hpp>
@@ -105,13 +104,15 @@ private:
 // default filename
   std::string fileName;
 // parser
-  DOMBuilder * parser;
+  DOMLSParser * parser;
 // document
- DOMDocument * doc;
+  DOMDocument * doc;
 // main node
- DOMNode * mn;
+  DOMNode * mn;
 // writer
- DOMWriter * writer;
+  DOMLSSerializer * serializer;
+//output
+  DOMLSOutput* outputDesc;
 
 // Constants
  XMLCh * id_string;

--- a/TotemProtonTransport/TotemRPProtonTransportParametrization/src/RPXMLConfig.cc
+++ b/TotemProtonTransport/TotemRPProtonTransportParametrization/src/RPXMLConfig.cc
@@ -29,11 +29,14 @@ RPXMLConfig::RPXMLConfig ()
     DOMImplementationRegistry::getDOMImplementation (tempStr);
   this->parser =
     ((DOMImplementationLS *) impl)->
-    createDOMBuilder (DOMImplementationLS::MODE_SYNCHRONOUS, 0);
-  this->writer = ((DOMImplementationLS *) impl)->createDOMWriter ();
+    createLSParser (DOMImplementationLS::MODE_SYNCHRONOUS, 0);
 
-  if (this->writer->canSetFeature (XMLUni::fgDOMWRTFormatPrettyPrint, true))
-    this->writer->setFeature (XMLUni::fgDOMWRTFormatPrettyPrint, true);
+  this->serializer = ((DOMImplementationLS *) impl)->createLSSerializer ();
+  DOMConfiguration* dc = this->serializer->getDomConfig();
+  dc->setParameter(XMLUni::fgDOMWRTFormatPrettyPrint, true);
+
+  this->outputDesc = ((DOMImplementationLS*)impl)->createLSOutput();
+
 
   this->doc = 0;
 
@@ -68,7 +71,8 @@ void
 RPXMLConfig::save (const std::string filename)
 {
   XMLFormatTarget *myForm = new StdOutFormatTarget ();
-  writer->writeNode (myForm, *doc);
+  outputDesc->setByteStream(myForm);
+  serializer->write(doc, outputDesc);
 }
 
 void


### PR DESCRIPTION
Closes #13 

Due to change of xerces XML library change in CMSSW code which compiles in 810_pre5 will NOT compile in 810_pre8 (and vice versa).

This change updates code to latest xerces library. After merging thich PR code will NOT compile in 810_pre5 but will start to compile in 810_pre8.
